### PR TITLE
install pyclowder explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+# 2020-07-08
+
+## 2.1.0 - file/digest
+
+### Changed
+
+- redid building of container to use pyenv and install pyclowder
+
 # 2020-07-07
 
 ## 1.0.1 - audio/speech2text

--- a/digest/Dockerfile
+++ b/digest/Dockerfile
@@ -1,5 +1,25 @@
-FROM clowder/pyclowder:onbuild
+# ------------------------------------------------------------
+# create requirements.txt
+# ------------------------------------------------------------
+FROM python:3.7 AS pipenv
+RUN pip install pipenv
+COPY Pipfile* /tmp/
+RUN cd /tmp && pipenv lock --requirements > requirements.txt
 
-ENV RABBITMQ_QUEUE="ncsa.file.digest" \
-    MAIN_SCRIPT="ncsa.file.digest.py" \
-    EXTRACTOR_HASHLIST="md5","sha1","sha224","sha256","sha384","sha512"
+# ------------------------------------------------------------
+# build actual container
+# ------------------------------------------------------------
+FROM python:3-alpine
+
+ENV EXTRACTOR_HASHLIST="md5","sha1","sha224","sha256","sha384","sha512"
+
+# Install requirements
+WORKDIR /home/clowder
+COPY --from=pipenv /tmp/requirements.txt /home/clowder/
+RUN pip install -r /home/clowder/requirements.txt
+
+# Copy application
+COPY *.py *.json /home/clowder/
+
+# Start application
+CMD python /home/clowder/ncsa.file.digest.py

--- a/digest/Pipfile
+++ b/digest/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+pyclowder = "*"
+
+[requires]
+python_version = "3.7"

--- a/digest/Pipfile.lock
+++ b/digest/Pipfile.lock
@@ -1,0 +1,105 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "cbdeeb4adf2981d23719a996b578879a3b592b1bc7951227c94d7decc0b71583"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
+            ],
+            "version": "==2020.6.20"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "enum34": {
+            "hashes": [
+                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
+                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
+                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
+            ],
+            "version": "==1.1.6"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "pika": {
+            "hashes": [
+                "sha256:0b4c6cff9d156a3679eca6f71562535b172f54c69961be84d9bb704621319dc3",
+                "sha256:fba41293b35c845bd96cfdd29981f0eeff91f705ac0c3ba361a771c4bfbc3485"
+            ],
+            "version": "==1.0.0"
+        },
+        "pyclowder": {
+            "hashes": [
+                "sha256:1c2b7e75d1a4cf9fa812cbe95a821780bccc70bfe921b770f2a10c3221acaa7d",
+                "sha256:49345cd8929f56af16ef219d7a8ceb7d028d4a19ae8b89e53809ee0e856e7070"
+            ],
+            "index": "pypi",
+            "version": "==2.2.3"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c",
+                "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95",
+                "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2",
+                "sha256:5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4",
+                "sha256:7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad",
+                "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba",
+                "sha256:a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1",
+                "sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e",
+                "sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673",
+                "sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13",
+                "sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"
+            ],
+            "version": "==5.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.21.0"
+        },
+        "requests-toolbelt": {
+            "hashes": [
+                "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f",
+                "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"
+            ],
+            "version": "==0.9.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
+                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4'",
+            "version": "==1.24.3"
+        }
+    },
+    "develop": {}
+}

--- a/digest/extractor_info.json
+++ b/digest/extractor_info.json
@@ -1,7 +1,7 @@
 {
     "@context": "http://clowder.ncsa.illinois.edu/contexts/extractors.jsonld",
     "name": "ncsa.file.digest",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "File digest extractor",
     "author": "Max Burnette <mburnet2@illinois.edu>",
     "contributors": [],


### PR DESCRIPTION
update file digest to explicitly install pyclowder.

- use pipenv, which lock pyclowder to specific version
- update extractor dockerfile to use pipenv
