### PR TITLE
Move from alpine back to ubuntu (fix red band bug)

### DIFF
--- a/image/preview/Dockerfile
+++ b/image/preview/Dockerfile
@@ -17,11 +17,7 @@ ENV VERSION=${VERSION} \
 
 WORKDIR /extractor
 
-RUN apt update && apt-get install build-essential && \
-    wget https://www.imagemagick.org/download/ImageMagick.tar.gz && \
-    tar xvzf ImageMagick.tar.gz && \
-    cd ImageMagick-7.0.10-58/ && \
-    ./configure && make && make install && ldconfig /usr/local/lib
+RUN apt update && apt-get install -y build-essential imagemagick
 
 COPY requirements.txt ./
 RUN pip install -r requirements.txt

--- a/image/preview/Dockerfile
+++ b/image/preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.7
 
 ARG VERSION="unknown"
 ARG BUILDNUMBER="unknown"
@@ -12,14 +12,19 @@ ENV VERSION=${VERSION} \
     IMAGE_BINARY="/usr/bin/convert" \
     IMAGE_TYPE="png" \
     IMAGE_THUMBNAIL_COMMAND="@BINARY@ @INPUT@[0] -auto-orient -resize 225^ @OUTPUT@" \
-    IMAGE_PREVIEW_COMMAND="@BINARY@ @INPUT@[0] -auto-orient -resize 800x600 @OUTPUT@"
+    IMAGE_PREVIEW_COMMAND="@BINARY@ @INPUT@[0] -auto-orient -resize 800x600 @OUTPUT@" \
+    MAGICK_CONFIGURE_PATH='/extractor'
 
 WORKDIR /extractor
 
-RUN apk add --no-cache imagemagick
+RUN apt update && apt-get install build-essential && \
+    wget https://www.imagemagick.org/download/ImageMagick.tar.gz && \
+    tar xvzf ImageMagick.tar.gz && \
+    cd ImageMagick-7.0.10-58/ && \
+    ./configure && make && make install && ldconfig /usr/local/lib
 
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
 
-COPY binary_extractor.py extractor_info.json ./
+COPY binary_extractor.py extractor_info.json policy.xml ./
 CMD python binary_extractor.py

--- a/image/preview/extractor_info.json
+++ b/image/preview/extractor_info.json
@@ -1,7 +1,7 @@
 {
   "@context": "http://clowder.ncsa.illinois.edu/contexts/extractors.jsonld",
   "name": "ncsa.image.preview",
-  "version": "2.1.6",
+  "version": "2.2.0",
   "description": "Creates thumbnail and image previews of Image files.",
   "author": "Rob Kooper <kooper@illinois.edu>",
   "contributors": [

--- a/image/preview/policy.xml
+++ b/image/preview/policy.xml
@@ -1,5 +1,6 @@
 <policymap>
     <policy domain="resource" name="memory" value="6GiB"/>
+    <policy domain="resource" name="memory" value="20GiB"/>
     <policy domain="resource" name="width" value="30KP"/>
     <policy domain="resource" name="height" value="30KP"/>
 </policymap>

--- a/image/preview/policy.xml
+++ b/image/preview/policy.xml
@@ -1,4 +1,5 @@
 <policymap>
+    <policy domain="resource" name="memory" value="6GiB"/>
     <policy domain="resource" name="width" value="30KP"/>
     <policy domain="resource" name="height" value="30KP"/>
 </policymap>

--- a/image/preview/policy.xml
+++ b/image/preview/policy.xml
@@ -1,0 +1,4 @@
+<policymap>
+    <policy domain="resource" name="width" value="30KP"/>
+    <policy domain="resource" name="height" value="30KP"/>
+</policymap>


### PR DESCRIPTION
It seems that certain geotiff files were causing issues in the alpine image of the extractor, this adds an explicit imagemagick version and policy.xml file to increase input filesize limits.

This extractor will fail if the input exceeds the resources, rather tha upload a bad file like the red band images.