### PR TITLE
update filedigest for clowder v2

### DIFF
--- a/digest/ncsa.file.digest.py
+++ b/digest/ncsa.file.digest.py
@@ -12,7 +12,6 @@ from pyclowder.extractors import Extractor
 from pyclowder.utils import CheckMessage
 import pyclowder.files
 
-clowder_version = os.getenv('CLOWDER_VERSION', '1.0')
 
 class FileDigestCalculator(Extractor):
     def __init__(self):

--- a/digest/ncsa.file.digest.py
+++ b/digest/ncsa.file.digest.py
@@ -12,7 +12,7 @@ from pyclowder.extractors import Extractor
 from pyclowder.utils import CheckMessage
 import pyclowder.files
 
-clowder_version = os.getenv('CLOWDER_VERSION')
+clowder_version = os.getenv('CLOWDER_VERSION', '1.0')
 
 class FileDigestCalculator(Extractor):
     def __init__(self):

--- a/digest/ncsa.file.digest.py
+++ b/digest/ncsa.file.digest.py
@@ -87,20 +87,7 @@ class FileDigestCalculator(Extractor):
         for alg in self.hash_list:
             hash_context[alg] = "http://www.w3.org/2001/04/xmldsig-more#%s" % alg
 
-        if float(clowder_version) >= 2.0:
-            metadata = self.get_metadata(hash_digest, 'file', resource['id'], host, contexts=[hash_context])
-
-        else:
-            # store results as metadata
-            metadata = {
-                "@context": ["https://clowder.ncsa.illinois.edu/contexts/metadata.jsonld", hash_context],
-                "dataset_id": resource['parent'].get('id', None),
-                "content": hash_digest,
-                "agent": {
-                    "@type": "cat:extractor",
-                    "extractor_id": host + "api/extractors/" + self.extractor_info['name']
-                }
-            }
+        metadata = self.get_metadata(hash_digest, 'file', resource['id'], host, contexts=[hash_context])
 
         pyclowder.files.upload_metadata(connector, host, secret_key, resource['id'], metadata)
 


### PR DESCRIPTION
In order to run this branch, use this branch of pyclowder:

https://github.com/clowder-framework/pyclowder/tree/59-change-context-type-for-v2

Also, make sure to set the environment variable CLOWDER_VERSION=2.0