### PR TITLE
Accept ProRes files (need -pix_fmt).  Fix scale expression.

### DIFF
--- a/video/preview/Dockerfile
+++ b/video/preview/Dockerfile
@@ -16,7 +16,7 @@ ENV VERSION=${VERSION} \
     IMAGE_PREVIEW_COMMAND="@BINARY@ -y -i @INPUT@ -ss 1 -t 1 -r 1 -vcodec png -f rawvideo @OUTPUT@" \
     PREVIEW_BINARY="/usr/bin/ffmpeg" \
     PREVIEW_TYPE="mp4" \
-    PREVIEW_COMMAND="@BINARY@ -y -i @INPUT@ -c:v libx264 -profile:v baseline -preset slow -vf scale=-1:'min(ih,360)' -strict experimental -c:a aac -b:a 48k -movflags +faststart @OUTPUT@"
+    PREVIEW_COMMAND="@BINARY@ -y -i @INPUT@ -c:v libx264 -pix_fmt yuv420p -profile:v baseline -preset slow -vf scale=-1:'min(ih\,360)' -strict experimental -c:a aac -b:a 48k -movflags +faststart @OUTPUT@"
 
 WORKDIR /extractor
 


### PR DESCRIPTION
ffmpeg could fail to create a "baseline"-profile MP4 if the source movie uses a pixel format other than 4:2:0 (many but not all formats use 4:2:0).
ffmpeg's error report is buried in lots of other output, but it looks like:
   x264 [error]: baseline profile doesn't support 4:2:2


For example, movies in one of the Apple ProRes formats have 4:2:2 or 4:4:4 pixel formats.   Though these might be acceptable in non-"baseline" MP4 profiles, the ffmpeg H.264 wiki page ( https://trac.ffmpeg.org/wiki/Encode/H.264 ) warns that some players won't be able to play them.   It suggests the "-pix_fmt yuv420p" ffmpeg option to convert to the baseline pixel format.

Also, in trying to run the ffmpeg command in the Dockerfile, we get errors related to parsing the option
   -scale -1:'min(ih,360)'
This mysteriously seems to work if the above is changed to
    -scale -1:'min(ih\,360)'
