### PR TITLE
make width even in command

### DIFF
--- a/video/preview/Dockerfile
+++ b/video/preview/Dockerfile
@@ -16,7 +16,8 @@ ENV VERSION=${VERSION} \
     IMAGE_PREVIEW_COMMAND="@BINARY@ -y -i @INPUT@ -ss 1 -t 1 -r 1 -vcodec png -f rawvideo @OUTPUT@" \
     PREVIEW_BINARY="/usr/bin/ffmpeg" \
     PREVIEW_TYPE="mp4" \
-    PREVIEW_COMMAND="@BINARY@ -y -i @INPUT@ -c:v libx264 -profile:v baseline -preset slow -vf scale=-1:'min(ih,360)' -strict experimental -c:a aac -b:a 48k -movflags +faststart @OUTPUT@"
+    PREVIEW_COMMAND="@BINARY@ -y -i @INPUT@ -c:v libx264 -profile:v baseline -preset slow -vf scale='trunc(iw*min(360/ih\\,1)/2)*2:trunc(ih*min(360/ih\\,1)/2)*2' -strict experimental -c:a aac -b:a 48k -movflags +faststart @OUTPUT@"
+
 
 WORKDIR /extractor
 


### PR DESCRIPTION
#43 

Old command: -vf scale=-1:'min(ih,360)'
Width is auto-calculated (-1) to preserve aspect ratio 
I/p: 179 × 720        o/p : 179 × 360
libx264 requires even width

New command : -vf scale='trunc(iw*min(360/ih\,1)/2)*2:trunc(ih*min(360/ih\,1)/2)*2' 
min(360/ih, 1) → scaling factor
Apply the same scaling factor to height and width
Force even dimensions : trunc(value / 2) * 2